### PR TITLE
Prometheus DNS Discovery added

### DIFF
--- a/prometheus-compose/prometheus.yml
+++ b/prometheus-compose/prometheus.yml
@@ -14,6 +14,14 @@ rule_files:
 scrape_configs:
 
 scrape_configs:
-  - job_name: 'coinmarketcap'
-    static_configs:
-      - targets: ['coinmarketcap-exporter:9101']
+
+  - job_name: 'coinmarketcap-exporter'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    dns_sd_configs:
+    - names:
+      - 'tasks.coinmarketcap-exporter'
+      type: 'A'
+      port: 9101

--- a/prometheus-compose/prometheus.yml
+++ b/prometheus-compose/prometheus.yml
@@ -12,6 +12,8 @@ rule_files:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
+
+scrape_configs:
   - job_name: 'coinmarketcap'
     static_configs:
       - targets: ['coinmarketcap-exporter:9101']


### PR DESCRIPTION
Updated the scrape config to use DNS discovery which works easier in Swarm configs. 
@bonovoxly Let me know as I can also upgrade the compose stack if needed as well to 3.1

Thanks for creating this!

Signed-off-by: Brian Christner <brian.christner@gmail.com>