### PR TITLE
Several improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.6
-RUN pip install prometheus_client requests
+RUN pip install prometheus_client requests cachetools
 RUN mkdir -p /opt/coinmarketcap-exporter
-COPY ./Dockerfile /opt/coinmarketcap-exporter/
-COPY ./README.md /opt/coinmarketcap-exporter/
 COPY ./coinmarketcap.py /opt/coinmarketcap-exporter/
 WORKDIR /opt/coinmarketcap-exporter
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
-RUN pip install prometheus_client requests cachetools
-RUN mkdir -p /opt/coinmarketcap-exporter
-COPY ./coinmarketcap.py /opt/coinmarketcap-exporter/
+COPY ./requirements.txt /opt/coinmarketcap-exporter/requirements.txt
 WORKDIR /opt/coinmarketcap-exporter
+RUN pip install -r requirements.txt
+COPY ./coinmarketcap.py /opt/coinmarketcap-exporter/
 
 ENTRYPOINT ["python3", "coinmarketcap.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
-COPY ./requirements.txt /opt/coinmarketcap-exporter/requirements.txt
 WORKDIR /opt/coinmarketcap-exporter
+COPY ./requirements.txt .
 RUN pip install -r requirements.txt
-COPY ./coinmarketcap.py /opt/coinmarketcap-exporter/
+COPY ./coinmarketcap.py .
 
 ENTRYPOINT ["python3", "coinmarketcap.py"]

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ When running this exporter with both Prometheus and Grafana, [you can create das
 
 - Build the image:
 
-```
+```sh
 docker build -t coinmarketcap-exporter:latest .
 ```
 
 - Run it while listening on localhost:9100:
 
-```
+```sh
 docker run --rm -p 127.0.0.1:9101:9101 coinmarketcap-exporter:latest
 ```
 
 - Run it interactively:
 
-```
+```sh
 docker run --rm -it --entrypoint=/bin/bash -p 127.0.0.1:9101:9101 -v ${PWD}:/opt/coinmarketcap-exporter coinmarketcap-exporter:latest
 ```
 
 - Then to launch:
 
-```
+```sh
 python coinmarketcap.py
 ```
 
@@ -36,11 +36,11 @@ python coinmarketcap.py
 
 - In the `prometheus-compose` directory, run:
 
-```
+```sh
 docker-compose up
 ```
 
-- Go to <http://localhost:3000>.  Log in as `admin/admin`. 
+- Go to <http://localhost:3000>.  Log in as `admin/admin`.
 - To import the dashboard, click the "Home" button at the top, then on the right, click "Import Dashboard".
 - Enter `3890` in the "Grafana.com Dashboard" field.
 - Select the "prometheus" data source.

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -39,10 +39,10 @@ class CoinCollector():
 
 	def collect(self):
 		with lock:
+			log.info('collecting...')
 			start = 1
 			while True:
 				# query the api
-				log.info('starting with %d' % (start))
 				response = self.client.tickers(start)
 				if not response['data']:
 					break

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -63,17 +63,18 @@ class CoinCollector():
 				start += len(response['data'])
 
 if __name__ == '__main__':
-  try:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--port', nargs='?', const=9101, help='The TCP port to listen on.  Defaults to 9101.', default=9101)
-    args = parser.parse_args()
-    log.info('listening on ::%d' % (args.port))
+	try:
+		parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+		parser.add_argument('--port', nargs='?', const=9101, help='The TCP port to listen on', default=9101)
+		parser.add_argument('--addr', nargs='?', const='0.0.0.0', help='The interface to bind to', default='0.0.0.0')
+		args = parser.parse_args()
+		log.info('listening on http://%s:%d/metrics' % (args.addr, args.port))
 
-    REGISTRY.register(CoinCollector())
-    start_http_server(int(args.port))
+		REGISTRY.register(CoinCollector())
+		start_http_server(int(args.port), addr=args.addr)
 
-    while True:
-        time.sleep(60)
-  except KeyboardInterrupt:
-    print(" Interrupted")
-    exit(0)
+		while True:
+			time.sleep(60)
+	except KeyboardInterrupt:
+		print(" Interrupted")
+		exit(0)

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -1,13 +1,18 @@
 from prometheus_client import start_http_server, Metric, REGISTRY
+from threading import Lock
+from cachetools import cached, TTLCache
 import argparse
 import json
 import logging
 import requests
 import sys
 import time
-from threading import Lock
 
+# lock of the collect method
 lock = Lock()
+
+# caching API for 2min
+cache = TTLCache(maxsize=1000, ttl=120)
 
 # logging setup
 log = logging.getLogger('coinmarketcap-exporter')
@@ -18,49 +23,51 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 log.addHandler(ch)
 
-class CoinCollector():
-  def __init__(self):
-    self.endpoint = 'https://api.coinmarketcap.com/v2/ticker/'
 
-  def collect(self):
-	with lock:
-		start = 1
-		while True:
-			# query the api
-			print('starting with %d' % (start))
-			r = requests.get('%s?convert=BTC&start=%d' % (self.endpoint, start))
-			request_time = r.elapsed.total_seconds()
-			log.info('elapsed time -' + str(request_time))
-			response = json.loads(r.content.decode('UTF-8'))
-			if not response['data']:
-				break
-			# setup the metric
-			metric = Metric('coinmarketcap_response_time', 'Total time for the coinmarketcap API to respond.', 'summary')
-			# add the response time as a metric
-			metric.add_sample('coinmarketcap_response_time', value=float(request_time), labels={'name': 'coinmarketcap.com'})
-			yield metric
-			metric = Metric('coin_market', 'coinmarketcap metric values', 'gauge')
-			for _, value in response['data'].items():
-				for that in ['rank', 'total_supply', 'max_supply', 'circulating_supply']:
-					coinmarketmetric = '_'.join(['coin_market', that])
-					if value[that] is not None:
-						metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
-				for price in ['USD', 'BTC']:
-					for that in ['price', 'volume_24h', 'market_cap', 'percent_change_1h', 'percent_change_24h', 'percent_change_7d']:
-						coinmarketmetric = '_'.join(['coin_market', that, price]).lower()
-						if value['quotes'][price] is None:
-							continue
-						if value['quotes'][price][that] is not None:
-							metric.add_sample(coinmarketmetric, value=float(value['quotes'][price][that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
-			yield metric
-			start += len(response['data'])
+class CoinClient():
+	def __init__(self):
+		self.endpoint = 'https://api.coinmarketcap.com/v2/ticker/'
+
+	@cached(cache)
+	def tickers(self, start):
+		r = requests.get('%s?convert=BTC&start=%d' % (self.endpoint, start))
+		return json.loads(r.content.decode('UTF-8'))
+
+class CoinCollector():
+	def __init__(self):
+		self.client = CoinClient()
+
+	def collect(self):
+		with lock:
+			start = 1
+			while True:
+				# query the api
+				log.info('starting with %d' % (start))
+				response = self.client.tickers(start)
+				if not response['data']:
+					break
+				metric = Metric('coin_market', 'coinmarketcap metric values', 'gauge')
+				for _, value in response['data'].items():
+					for that in ['rank', 'total_supply', 'max_supply', 'circulating_supply']:
+						coinmarketmetric = '_'.join(['coin_market', that])
+						if value[that] is not None:
+							metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
+					for price in ['USD', 'BTC']:
+						for that in ['price', 'volume_24h', 'market_cap', 'percent_change_1h', 'percent_change_24h', 'percent_change_7d']:
+							coinmarketmetric = '_'.join(['coin_market', that, price]).lower()
+							if value['quotes'][price] is None:
+								continue
+							if value['quotes'][price][that] is not None:
+								metric.add_sample(coinmarketmetric, value=float(value['quotes'][price][that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
+				yield metric
+				start += len(response['data'])
 
 if __name__ == '__main__':
   try:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--port', nargs='?', const=9101, help='The TCP port to listen on.  Defaults to 9101.', default=9101)
     args = parser.parse_args()
-    print('listening on ::%d' % (args.port))
+    log.info('listening on ::%d' % (args.port))
 
     REGISTRY.register(CoinCollector())
     start_http_server(int(args.port))

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -5,6 +5,9 @@ import logging
 import requests
 import sys
 import time
+from threading import Lock
+
+lock = Lock()
 
 # logging setup
 log = logging.getLogger('coinmarketcap-exporter')
@@ -20,50 +23,50 @@ class CoinCollector():
     self.endpoint = 'https://api.coinmarketcap.com/v2/ticker/'
 
   def collect(self):
-    start = 1
-    while True:
-        # query the api
-        print('starting with %d' % (start))
-        r = requests.get('%s?convert=BTC&start=%d' % (self.endpoint, start))
-        request_time = r.elapsed.total_seconds()
-        log.info('elapsed time -' + str(request_time))
-        response = json.loads(r.content.decode('UTF-8'))
-        if not response['data']:
-            break
-        # setup the metric
-        metric = Metric('coinmarketcap_response_time', 'Total time for the coinmarketcap API to respond.', 'summary')
-        # add the response time as a metric
-        metric.add_sample('coinmarketcap_response_time', value=float(request_time), labels={'name': 'coinmarketcap.com'})
-        yield metric
-        metric = Metric('coin_market', 'coinmarketcap metric values', 'gauge')
-        for _, value in response['data'].items():
-            for that in ['rank', 'total_supply', 'max_supply', 'circulating_supply']:
-                coinmarketmetric = '_'.join(['coin_market', that])
-                if value[that] is not None:
-                    metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
-            for price in ['USD', 'BTC']:
-                for that in ['price', 'volume_24h', 'market_cap', 'percent_change_1h', 'percent_change_24h', 'percent_change_7d']:
-                    coinmarketmetric = '_'.join(['coin_market', that, price]).lower()
-                    if value['quotes'][price] is None:
-                        continue
-                    if value['quotes'][price][that] is not None:
-                        metric.add_sample(coinmarketmetric, value=float(value['quotes'][price][that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
-        yield metric
-        start += len(response['data'])
+	with lock:
+		start = 1
+		while True:
+			# query the api
+			print('starting with %d' % (start))
+			r = requests.get('%s?convert=BTC&start=%d' % (self.endpoint, start))
+			request_time = r.elapsed.total_seconds()
+			log.info('elapsed time -' + str(request_time))
+			response = json.loads(r.content.decode('UTF-8'))
+			if not response['data']:
+				break
+			# setup the metric
+			metric = Metric('coinmarketcap_response_time', 'Total time for the coinmarketcap API to respond.', 'summary')
+			# add the response time as a metric
+			metric.add_sample('coinmarketcap_response_time', value=float(request_time), labels={'name': 'coinmarketcap.com'})
+			yield metric
+			metric = Metric('coin_market', 'coinmarketcap metric values', 'gauge')
+			for _, value in response['data'].items():
+				for that in ['rank', 'total_supply', 'max_supply', 'circulating_supply']:
+					coinmarketmetric = '_'.join(['coin_market', that])
+					if value[that] is not None:
+						metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
+				for price in ['USD', 'BTC']:
+					for that in ['price', 'volume_24h', 'market_cap', 'percent_change_1h', 'percent_change_24h', 'percent_change_7d']:
+						coinmarketmetric = '_'.join(['coin_market', that, price]).lower()
+						if value['quotes'][price] is None:
+							continue
+						if value['quotes'][price][that] is not None:
+							metric.add_sample(coinmarketmetric, value=float(value['quotes'][price][that]), labels={'id': value['website_slug'], 'name': value['name'], 'symbol': value['symbol']})
+			yield metric
+			start += len(response['data'])
 
 if __name__ == '__main__':
   try:
-    parser = argparse.ArgumentParser(
-      description=__doc__,
-      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--port', nargs='?', const=9101, help='The TCP port to listen on.  Defaults to 9101.', default=9101)
     args = parser.parse_args()
-    log.info(args.port)
+    print('listening on ::%d' % (args.port))
 
     REGISTRY.register(CoinCollector())
     start_http_server(int(args.port))
+
     while True:
-      time.sleep(60)
+        time.sleep(60)
   except KeyboardInterrupt:
     print(" Interrupted")
     exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+cachetools==3.0.0
+certifi==2018.11.29
+chardet==3.0.4
+greenlet==0.4.15
+idna==2.8
+msgpack==0.5.6
+neovim==0.3.0
+prometheus-client==0.5.0
+requests==2.21.0
+urllib3==1.24.1


### PR DESCRIPTION
- added a Client class with 2min cache
- added a lock to the collect method so we don't do many requests at the same time
- improved some logs
- improved dockerfile
- fixed deps with a `requirements.txt`
- added a bind address option (so the user can listen locally only if they want to)

Image with the results is pushed to `caarlos0/coinmarketcap-exporter` if you wish to test it.

Those changes have the intent to increase the stability of the whole thing... The ticker API is cached to 1min either way, so we are just keeping it for 1 min more.

FWIW, this API is now also deprecated because they are launching a paid one :/ 