### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-alpine
 WORKDIR /opt/coinmarketcap-exporter
 COPY ./requirements.txt .
-RUN apk --no-cache add --virtual build-dependencies python-dev build-base \
+RUN apk --no-cache add --virtual build-dependencies build-base \
     && pip install -r requirements.txt \
     && apk del build-dependencies
 COPY ./coinmarketcap.py .


### PR DESCRIPTION
Fixed Dockerfile.

There is no python-dev package for the alpine image python:3.7-alpine is based on and it breaks image build.
However, it seems not to be required.