### PR TITLE
Added timestamp to metrics

### DIFF
--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -47,6 +47,7 @@ class CoinClient():
     if 'data' not in data:
       log.error('No data in response. Is your API key set?')
       log.info(data)
+    data['timestamp'] = time.time()
     return data
 
 class CoinCollector():
@@ -66,14 +67,14 @@ class CoinCollector():
           for that in ['cmc_rank', 'total_supply', 'max_supply', 'circulating_supply']:
             coinmarketmetric = '_'.join(['coin_market', that])
             if value[that] is not None:
-              metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['slug'], 'name': value['name'], 'symbol': value['symbol']})
+              metric.add_sample(coinmarketmetric, value=float(value[that]), labels={'id': value['slug'], 'name': value['name'], 'symbol': value['symbol']}, timestamp=response['timestamp'])
           for price in [currency]:
             for that in ['price', 'volume_24h', 'market_cap', 'percent_change_1h', 'percent_change_24h', 'percent_change_7d']:
               coinmarketmetric = '_'.join(['coin_market', that, price]).lower()
               if value['quote'][price] is None:
                 continue
               if value['quote'][price][that] is not None:
-                metric.add_sample(coinmarketmetric, value=float(value['quote'][price][that]), labels={'id': value['slug'], 'name': value['name'], 'symbol': value['symbol']})
+                metric.add_sample(coinmarketmetric, value=float(value['quote'][price][that]), labels={'id': value['slug'], 'name': value['name'], 'symbol': value['symbol']}, timestamp=response['timestamp'])
       yield metric
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added timestamp to metrics to avoid repeated data to me added to the database (with current time as timestamp) while API is caching.

I know that is not very Prometheus-friendly and that the graphs will look a little bit strange (for being a discrete function), but in my opinion we need to know the exact measurement time (since considering that the value did not change for the entire cache TTL - which in most cases will be at least a few tens of minutes - would lead to irelevant assumptions).

![example](https://user-images.githubusercontent.com/5727160/115932053-dcb69380-a494-11eb-91af-69bfc02f1827.png)

The result will look as the right side of the graphic in the image above (I have a ~2h CACHE TTL on my deployment). Not so good looking, but more accurate than the left side which lies as about the rate being constant for 2 hours.

In my implementation, I have added all the metrics using the time of the API call as timestamp. A more accurate assumption would be to use the value of "last_updated" from CoinMarketCap. However, I am afraid that can yield inconsistencies on timestamp monotony which (for the best of my knowledge - I am pretty new with Prometheus - can lead to Prometheus discarding some of the values just for being to far from the last timestamp).

  